### PR TITLE
Added trimming option before validation

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,4 +1,6 @@
 class Email < ContactAttribute
+  include ActiveModel::Validations::Callbacks
+
   self.attribute_keys = [:_id, :_type, :public, :primary, :category, :value, :contact_id]
   self.hydra = Contacts::HYDRA
   self.resource_path = "/v0/contact_attributes"
@@ -7,6 +9,8 @@ class Email < ContactAttribute
   self.api_key = Contacts::API_KEY
   self.host  = Contacts::HOST
 
+  before_validation :strip_whitespace
+
   attr_accessor :category, :value, :public, :primary
 
   def _type
@@ -14,4 +18,9 @@ class Email < ContactAttribute
   end
 
   validates :value, :email_format => true
+
+  private
+    def strip_whitespace
+      self.value = self.value.strip
+    end
 end

--- a/app/models/telephone.rb
+++ b/app/models/telephone.rb
@@ -1,4 +1,6 @@
 class Telephone < ContactAttribute
+  include ActiveModel::Validations::Callbacks
+
   self.attribute_keys = [:_id, :_type, :public, :primary, :category, :value, :contact_id]
   self.hydra = Contacts::HYDRA
   self.resource_path = "/v0/contact_attributes"
@@ -9,6 +11,8 @@ class Telephone < ContactAttribute
 
   attr_accessor :category, :value, :public, :primary
 
+  before_validation :strip_whitespace
+
   validates :value, :numericality => true, :unless => :masked?
 
   def masked?
@@ -18,4 +22,9 @@ class Telephone < ContactAttribute
   def _type
     self.class.name
   end
+
+  private
+    def strip_whitespace
+      self.value = self.value.strip
+    end
 end


### PR DESCRIPTION
Email and Telephone trim their values before making a validation. To achieve this ActiveModel::Validations::Callbacks must be included, and this could be in LogicalModel instead of each of these models
