### PR TITLE
remove numericality validation for telephone

### DIFF
--- a/app/models/telephone.rb
+++ b/app/models/telephone.rb
@@ -1,5 +1,6 @@
 class Telephone < ContactAttribute
   include ActiveModel::Validations::Callbacks
+  before_validation :strip_whitespace
 
   self.attribute_keys = [:_id, :_type, :public, :primary, :category, :value, :contact_id]
   self.hydra = Contacts::HYDRA
@@ -18,4 +19,9 @@ class Telephone < ContactAttribute
   def _type
     self.class.name
   end
+
+  private
+    def strip_whitespace
+      self.value = self.value.strip
+    end
 end


### PR DESCRIPTION
Numericality validation has been removed from contacts-ws. 
