### PR TITLE
add membership as padma_contact attribute

### DIFF
--- a/app/models/padma_contact.rb
+++ b/app/models/padma_contact.rb
@@ -33,6 +33,8 @@ class PadmaContact < LogicalModel
   attribute :observation
   attribute :in_professional_training
 
+  attribute :membership
+
   has_many :contact_attributes
   has_many :attachments
   has_many :tags


### PR DESCRIPTION
agregué este atributo, que va a estar vacio por default y se va a llenar según necesidad (por ejemplo en el contacts controller de crm cuando se requiere alguna columna de fnz.